### PR TITLE
fix(crypto): check permissions before deleting invoking message

### DIFF
--- a/src/commands/Cryptography/aes.ts
+++ b/src/commands/Cryptography/aes.ts
@@ -1,8 +1,8 @@
-import { AstraeaCommand, AstraeaCommandOptions } from '../../lib/Structures/Command'
-import { Message } from 'discord.js'
 import { ApplyOptions } from '@sapphire/decorators'
 import { Args } from '@sapphire/framework'
 import crypto from 'crypto-js'
+import { Message, Permissions } from 'discord.js'
+import { AstraeaCommand, AstraeaCommandOptions } from '../../lib/Structures/Command'
 
 @ApplyOptions<AstraeaCommandOptions>({
 	name: 'aes',
@@ -13,15 +13,18 @@ import crypto from 'crypto-js'
 })
 export default class AES extends AstraeaCommand {
 	public async run (message: Message, args: Args): Promise<Message> {
-		const decryptFlags = args.getFlags('d', 'decrypt')
+		const decryptFlag = args.getFlags('d', 'decrypt')
 		const text = (await args.restResult('string')).value
 		const secret = args.getOption('s', 'secret')
 
 		if (!text) return await message.channel.send('No text provided')
 		if (!secret) return await message.channel.send('No secret provided. (Hint: Use -s=<randomLetters> or --secret=<randomLetters>)')
 
-		if (decryptFlags) return await this.decrypt(message, text, secret).catch(async () => await message.channel.send('Decryption unsuccessful!'))
-		return await this.encrypt(message, text, secret)
+		if (message.guild.me.hasPermission(Permissions.FLAGS.MANAGE_MESSAGES)) void message.delete()
+
+		const result = decryptFlag ? this.decrypt(text, secret) : this.encrypt(text, secret)
+
+		return await message.channel.send(result)
 	}
 
 	/**
@@ -29,12 +32,8 @@ export default class AES extends AstraeaCommand {
 	 * Secret: ABC
 	 * Output: U2FsdGVkX1+Ocg9Sepezl979pPZ60p54jzzOEeVt98I=
 	 */
-	private async encrypt (message: Message, input: string, secret: string): Promise<Message> {
-		await message.delete()
-
-		const encrypted = crypto.AES.encrypt(input, secret).toString()
-
-		return await message.channel.send(encrypted)
+	private encrypt (input: string, secret: string): string {
+		return crypto.AES.encrypt(input, secret).toString()
 	}
 
 	/**
@@ -42,11 +41,7 @@ export default class AES extends AstraeaCommand {
 	 * Secret: ABC
 	 * Output: ABC
 	 */
-	private async decrypt (message: Message, input: string, secret: string): Promise<Message> {
-		await message.delete()
-
-		const decrypted = crypto.AES.decrypt(input, secret).toString(crypto.enc.Utf8).toString()
-
-		return await message.channel.send(decrypted)
+	private decrypt (input: string, secret: string): string {
+		return crypto.AES.decrypt(input, secret).toString(crypto.enc.Utf8).toString() || 'Decryption Unsuccessful'
 	}
 }

--- a/src/commands/Cryptography/des.ts
+++ b/src/commands/Cryptography/des.ts
@@ -1,8 +1,8 @@
-import { AstraeaCommand, AstraeaCommandOptions } from '../../lib/Structures/Command'
-import { Message } from 'discord.js'
 import { ApplyOptions } from '@sapphire/decorators'
 import { Args } from '@sapphire/framework'
 import crypto from 'crypto-js'
+import { Message, Permissions } from 'discord.js'
+import { AstraeaCommand, AstraeaCommandOptions } from '../../lib/Structures/Command'
 
 @ApplyOptions<AstraeaCommandOptions>({
 	name: 'des',
@@ -21,8 +21,11 @@ export default class DES extends AstraeaCommand {
 		if (!text) return await message.channel.send('No text provided.')
 		if (!secret) return await message.channel.send('No secret provided. (Hint: use --secret=<randomText> or -s=<randomText>)')
 
-		if (decryptFlag) return await this.Decrypt(message, text, secret, tripleFlag).catch(async () => await message.channel.send('Decryption unsuccessful!'))
-		return await this.Encrypt(message, text, secret, tripleFlag)
+		if (message.guild.me.hasPermission(Permissions.FLAGS.MANAGE_MESSAGES)) void message.delete()
+
+		const result = decryptFlag ? this.decrypt(text, secret, tripleFlag) : this.encrypt(text, secret, tripleFlag)
+
+		return await message.channel.send(result)
 	}
 
 	/**
@@ -38,17 +41,12 @@ export default class DES extends AstraeaCommand {
 	 * Secret: ABC
 	 * Output: U2FsdGVkX1/JdlBm8M+tXszBgkrIzCjX (Output may vary)
 	 */
-	private async Encrypt (message: Message, text: string, secret: string, triple?: boolean): Promise<Message> {
-		let encrypted: string
-
-		// DES is applied 3 times. It is believed that it is secure in this form
-		if (triple) {
-			encrypted = crypto.TripleDES.encrypt(text, secret).toString()
-		} else {
-			encrypted = crypto.DES.encrypt(text, secret).toString()
-		}
-
-		return await message.channel.send(encrypted)
+	private encrypt (text: string, secret: string, triple?: boolean): string {
+		// For TripleDES, DES is applied thrice. It is believed that it is secure in this form
+		return (triple
+			? crypto.TripleDES.encrypt(text, secret)
+			: crypto.DES.encrypt(text, secret)
+		).toString()
 	}
 
 	/**
@@ -64,15 +62,10 @@ export default class DES extends AstraeaCommand {
 	 * Secret: ABC
 	 * Output: ABC
 	 */
-	private async Decrypt (message: Message, text: string, secret: string, triple?: boolean): Promise<Message> {
-		let decrypted: string
-
-		if (triple) {
-			decrypted = crypto.TripleDES.decrypt(text, secret).toString(crypto.enc.Utf8)
-		} else {
-			decrypted = crypto.DES.decrypt(text, secret).toString(crypto.enc.Utf8)
-		}
-
-		return await message.channel.send(decrypted)
+	private decrypt (text: string, secret: string, triple?: boolean): string {
+		return (triple
+			? crypto.TripleDES.decrypt(text, secret)
+			: crypto.DES.decrypt(text, secret)
+		).toString()
 	}
 }

--- a/src/commands/Cryptography/rabbit.ts
+++ b/src/commands/Cryptography/rabbit.ts
@@ -1,8 +1,8 @@
-import { AstraeaCommand, AstraeaCommandOptions } from '../../lib/Structures/Command'
-import { Message } from 'discord.js'
 import { ApplyOptions } from '@sapphire/decorators'
 import { Args } from '@sapphire/framework'
 import crypto from 'crypto-js'
+import { Message, Permissions } from 'discord.js'
+import { AstraeaCommand, AstraeaCommandOptions } from '../../lib/Structures/Command'
 
 @ApplyOptions<AstraeaCommandOptions>({
 	name: 'rabbit',
@@ -13,15 +13,18 @@ import crypto from 'crypto-js'
 })
 export default class Rabbit extends AstraeaCommand {
 	public async run (message: Message, args: Args): Promise<Message> {
-		const decryptFlags = args.getFlags('d', 'decrypt')
+		const decryptFlag = args.getFlags('d', 'decrypt')
 		const text = (await args.restResult('string')).value
 		const secret = args.getOption('s', 'secret')
 
 		if (!text) return await message.channel.send('No text provided')
 		if (!secret) return await message.channel.send('No secret provided. (Hint: Use -s=<randomLetters> or --secret=<randomLetters>)')
 
-		if (decryptFlags) return await this.decrypt(message, text, secret).catch(async () => await message.channel.send('Couldn\'t decrypt this text!'))
-		return await this.encrypt(message, text, secret)
+		if (message.guild.me.hasPermission(Permissions.FLAGS.MANAGE_MESSAGES)) void message.delete()
+
+		const result = decryptFlag ? this.decrypt(text, secret) : this.encrypt(text, secret)
+
+		return await message.channel.send(result)
 	}
 
 	/**
@@ -29,12 +32,8 @@ export default class Rabbit extends AstraeaCommand {
 	 * Secret: ABC
 	 * Output: U2FsdGVkX1+dH8sIK4GYwBDZ2o0=
 	 */
-	private async encrypt (message: Message, input: string, secret: string): Promise<Message> {
-		await message.delete()
-
-		const encrypted = crypto.Rabbit.encrypt(input, secret).toString()
-
-		return await message.channel.send(encrypted)
+	private encrypt (input: string, secret: string): string {
+		return crypto.Rabbit.encrypt(input, secret).toString()
 	}
 
 	/**
@@ -42,11 +41,7 @@ export default class Rabbit extends AstraeaCommand {
 	 * Secret: ABC
 	 * Output: ABC
 	 */
-	private async decrypt (message: Message, input: string, secret: string): Promise<Message> {
-		await message.delete()
-
-		const decrypted = crypto.Rabbit.decrypt(input, secret).toString(crypto.enc.Utf8)
-
-		return await message.channel.send(decrypted)
+	private decrypt (input: string, secret: string): string {
+		return crypto.Rabbit.decrypt(input, secret).toString(crypto.enc.Utf8).toString()
 	}
 }


### PR DESCRIPTION
check for client's `MANAGE_MESSAGES` permission before deleting message

also clean up crypto commands for improved readability and less duplicate code

Closes #23